### PR TITLE
fix default range for odd-length arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function(arr, options) {
     options = { range: options };
   }
 
-  var defaults = {range: arr.length / 2, format: toFixed};
+  var defaults = {range: Math.round(arr.length / 2), format: toFixed};
   var opts = extend({}, defaults, options);
   var range = opts.range;
 

--- a/test.js
+++ b/test.js
@@ -20,6 +20,18 @@ describe('exponential-moving-average', function() {
       ema([1, 2, 3, 4, 5], 10);
     });
   });
+  
+  it('should select an appropriate default range for even-length input', function() {
+    var fixture = ['1.00', '1.00', '1.00', '1.00'];
+    
+    assert.deepEqual(ema(fixture), ['1.00', '1.00', '1.00']);
+  });
+  
+  it('should select an appropriate default range for odd-length input', function() {
+    var fixture = ['1.00', '1.00', '1.00'];
+    
+    assert.deepEqual(ema(fixture), ['1.00', '1.00']);
+  });
 
   it('should calculate exponential moving average', function() {
     var fixture = ['22.27', '22.19', '22.08', '22.17', '22.18', '22.13', '22.23', '22.43', '22.24', '22.29', '22.15', '22.39', '22.38', '22.61', '23.36', '24.05', '23.75', '23.83', '23.95', '23.63', '23.82', '23.87', '23.65', '23.19', '23.10', '23.33', '22.68', '23.10', '22.40', '22.17'];


### PR DESCRIPTION
Relying on the default range for an array of odd length results in `NaN` values in the result.